### PR TITLE
added enum parsing #18

### DIFF
--- a/IgniteCLI/Ignite-CLI/CLI.cs
+++ b/IgniteCLI/Ignite-CLI/CLI.cs
@@ -17,6 +17,7 @@ namespace IgniteCLI
         public static string String(Dictionary<string, string> d, string key) => d.ContainsKey(key.ToLower()) ? d[key.ToLower()] : null;
         public static int Int(Dictionary<string, string> d, string key) => Convert.ToInt32(CLI.String(d, key));
         public static bool Bool(Dictionary<string, string> d, string key) => d.ContainsKey(key.ToLower()) ? d[key.ToLower()] == "true" : false;
+        public static T ArgToEnum<T>(Dictionary<string, string> d, string key) => String(d, key).ToEnum<T>();
         #endregion
 
         private static CommandList Commands;

--- a/IgniteCLI/Ignite-CLI/Extensions.cs
+++ b/IgniteCLI/Ignite-CLI/Extensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IgniteCLI
+{
+    public static class StringExtensions
+    {
+        public static T ToEnum<T>(this string value)
+        {
+            return (T)Enum.Parse(typeof(T), value, true);
+        }
+    }
+}


### PR DESCRIPTION
added `CLI.ArgToEnum<T>(d, key)`
However, I don't like the naming. But if I leave it as `Enum()` (following the same nomenclature as the other convenience argument-parsing functions) then accessing the `Enum` class would have to be done by calling `System.Enum` in any file that had `using IgniteCLI;`

Therefore, **this PR is not complete until a naming decision is made**
Thoughts @ctennery-omega ?

Resolves #18 