### PR TITLE
Condensed the contents of Help command & Clarified the error

### DIFF
--- a/IgniteCLI/Ignite-CLI/CLI.cs
+++ b/IgniteCLI/Ignite-CLI/CLI.cs
@@ -114,8 +114,7 @@ namespace IgniteCLI
 
         public static void Help()
         {
-            Out("HELP:");
-            Out("cmd -arg [value] {-optionalArg [optional value]} {-optionalBool}");
+            Out("HELP: cmd -arg [value] {-optionalArg [optional value]} {-optionalBool}");
             Break();
             foreach (var cmd in Commands)
             {
@@ -125,7 +124,6 @@ namespace IgniteCLI
                 {
                     Out($"| {arg.Tag} : {arg.Description}", ConsoleColor.DarkCyan);
                 }
-                Out();
             }
             Break();
         }
@@ -147,8 +145,7 @@ namespace IgniteCLI
             catch (Exception e)
             {
                 sw.Stop();
-                CLI.Out(e.Message, ConsoleColor.Red);
-                CLI.Help();
+                CLI.Out("ERROR: " + e.Message, ConsoleColor.Red);
             }
         }
 


### PR DESCRIPTION
Resolves `#16`

1. Removed `CLI.Help();` to not be called when error occurs
2. Added `ERROR:` prefix to the error message
3. Merged `HELP:` and `cmd -arg...` strings into one `Out();`
4. Removed line break between each displayed command when `CLI.Help();` is called