### PR TITLE
#18 added enum parsing

### DIFF
--- a/IgniteCLI/Ignite-CLI/CLI.cs
+++ b/IgniteCLI/Ignite-CLI/CLI.cs
@@ -14,10 +14,10 @@ namespace IgniteCLI
     public class CLI
     {
         #region Convenience Functions
-        public static string String(Dictionary<string, string> d, string key) => d.ContainsKey(key.ToLower()) ? d[key.ToLower()] : null;
-        public static int Int(Dictionary<string, string> d, string key) => Convert.ToInt32(CLI.String(d, key));
-        public static bool Bool(Dictionary<string, string> d, string key) => d.ContainsKey(key.ToLower()) ? d[key.ToLower()] == "true" : false;
-        public static T ArgToEnum<T>(Dictionary<string, string> d, string key) => String(d, key).ToEnum<T>();
+        public static string StringArg(Dictionary<string, string> args, string key) => args.ContainsKey(key.ToLower()) ? args[key.ToLower()] : null;
+        public static int? IntArg(Dictionary<string, string> args, string key) => StringArg(args, key) != null ? Convert.ToInt32(StringArg(args, key)) : (int?)null;
+        public static bool BoolArg(Dictionary<string, string> args, string key) => args.ContainsKey(key.ToLower()) ? args[key.ToLower()].ToLower() == "true" : false;
+        public static T EnumArg<T>(Dictionary<string, string> args, string key) => StringArg(args, key).ToEnum<T>();
         #endregion
 
         private static CommandList Commands;

--- a/IgniteCLI/Ignite-CLI/CLI.cs
+++ b/IgniteCLI/Ignite-CLI/CLI.cs
@@ -17,6 +17,7 @@ namespace IgniteCLI
         public static string String(Dictionary<string, string> d, string key) => d.ContainsKey(key.ToLower()) ? d[key.ToLower()] : null;
         public static int Int(Dictionary<string, string> d, string key) => Convert.ToInt32(CLI.String(d, key));
         public static bool Bool(Dictionary<string, string> d, string key) => d.ContainsKey(key.ToLower()) ? d[key.ToLower()] == "true" : false;
+        public static T ArgToEnum<T>(Dictionary<string, string> d, string key) => String(d, key).ToEnum<T>();
         #endregion
 
         private static CommandList Commands;
@@ -46,7 +47,7 @@ namespace IgniteCLI
         public static void Start(CommandList commands)
         {
             Commands = commands;
-            foreach(var cmd in DefaultCommands)
+            foreach (var cmd in DefaultCommands)
             {
                 if (!Commands.Any(x => x.Name == cmd.Name))
                     Commands.Insert(0, cmd);
@@ -114,7 +115,8 @@ namespace IgniteCLI
 
         public static void Help()
         {
-            Out("HELP: cmd -arg [value] {-optionalArg [optional value]} {-optionalBool}");
+            Out("HELP:");
+            Out("cmd -arg [value] {-optionalArg [optional value]} {-optionalBool}");
             Break();
             foreach (var cmd in Commands)
             {
@@ -124,6 +126,7 @@ namespace IgniteCLI
                 {
                     Out($"| {arg.Tag} : {arg.Description}", ConsoleColor.DarkCyan);
                 }
+                Out();
             }
             Break();
         }
@@ -145,7 +148,8 @@ namespace IgniteCLI
             catch (Exception e)
             {
                 sw.Stop();
-                CLI.Out("ERROR: " + e.Message, ConsoleColor.Red);
+                CLI.Out(e.Message, ConsoleColor.Red);
+                CLI.Help();
             }
         }
 

--- a/IgniteCLI/Ignite-CLI/Extensions.cs
+++ b/IgniteCLI/Ignite-CLI/Extensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+namespace IgniteCLI
+{
+    public static class StringExtensions
+    {
+        public static T ToEnum<T>(this string value)
+        {
+            return (T)Enum.Parse(typeof(T), value, true);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ Ignite lets you simulate user input for programmatic command execution
 
 During command functions, Ignite provides quick methods to automatically parse and convert arguments
 
--   `CLI.String(Dictionary<string, string> d, string key)`
+-   `CLI.StringArg(Dictionary<string, string> args, string key)`
     -   Parses the value from the `Dictionary<string, string>` as a String
--   `CLI.Int(Dictionary<string, string> d, string key)`
+-   `CLI.IntArg(Dictionary<string, string> args, string key)`
     -   Parses the value from the `Dictionary<string, string>` as a Int
--   `CLI.Bool(Dictionary<string, string> d, string key)`
+-   `CLI.EnumArg<T>(Dictionary<string, string> args, string key)`
+    -   Parses the value from the `Dictionary<string, string>` as a value for the given Enum `T`
+-   `CLI.BoolArg(Dictionary<string, string> args, string key)`
     -   Parses the value from the `Dictionary<string, string>` as a Bool
     -   "true" and "false" are evaluated appropriately
     -   When no value is given, it is evaluated as true


### PR DESCRIPTION
added `CLI.ArgToEnum<T>(d, key)`
However, I don't like the naming. But if I leave it as `Enum()` (following the same nomenclature as the other convenience argument-parsing functions) then accessing the `Enum` class would have to be done by calling `System.Enum` in any file that had `using IgniteCLI;`

Therefore, this PR is not complete until a naming decision is made
Thoughts @ctennery-omega ?

Resolves #18