### PR TITLE
#34 added command aliases and commandarg aliases

### DIFF
--- a/IgniteCLI/Ignite-CLI/CLI.cs
+++ b/IgniteCLI/Ignite-CLI/CLI.cs
@@ -14,10 +14,10 @@ namespace IgniteCLI
     public class CLI
     {
         #region Convenience Functions
-        public static string StringArg(Dictionary<string, string> args, string key) => args.ContainsKey(key.ToLower()) ? args[key.ToLower()] : null;
-        public static int? IntArg(Dictionary<string, string> args, string key) => StringArg(args, key) != null ? Convert.ToInt32(StringArg(args, key)) : (int?)null;
-        public static bool BoolArg(Dictionary<string, string> args, string key) => args.ContainsKey(key.ToLower()) ? args[key.ToLower()].ToLower() == "true" : false;
-        public static T EnumArg<T>(Dictionary<string, string> args, string key) => StringArg(args, key).ToEnum<T>();
+        public static string String(Dictionary<string, string> args, string key) => args.ContainsKey(key.ToLower()) ? args[key.ToLower()] : null;
+        public static int? Int(Dictionary<string, string> args, string key) => String(args, key) != null ? Convert.ToInt32(String(args, key)) : (int?)null;
+        public static bool Bool(Dictionary<string, string> args, string key) => args.ContainsKey(key.ToLower()) ? args[key.ToLower()].ToLower() == "true" : false;
+        public static T Enum<T>(Dictionary<string, string> args, string key) => String(args, key).ToEnum<T>();
         #endregion
 
         private static CommandList Commands;
@@ -29,7 +29,7 @@ namespace IgniteCLI
                 Description = "Displays examples for all available console colors",
                 Function = args =>
                 {
-                    var colors = Enum.GetValues(typeof(ConsoleColor)).Cast<ConsoleColor>();
+                    var colors = System.Enum.GetValues(typeof(ConsoleColor)).Cast<ConsoleColor>();
                     foreach (var c in colors)
                         CLI.Out(c.ToString(), c);
                     foreach (var c in colors)
@@ -59,13 +59,12 @@ namespace IgniteCLI
             var input = Console.ReadLine();
             while (input != "exit")
             {
-                InputCommand cmd = ParseInput(input);
-
                 if (input.Length != 0)
                 {
-                    Run(cmd);
+                    Run(input);
                     CLI.Out();
                 }
+
                 Console.Write("> ");
                 input = Console.ReadLine();
             }
@@ -89,7 +88,7 @@ namespace IgniteCLI
                             cmdArgs.Add(t, "true");
                     }
                 }
-                catch { }
+                catch { } //TODO: not this
             }
             else
             {

--- a/IgniteCLI/Ignite-CLI/Command.cs
+++ b/IgniteCLI/Ignite-CLI/Command.cs
@@ -8,7 +8,7 @@ namespace IgniteCLI
     {
         public Command this[string s]
         {
-            get { return this.FirstOrDefault(x => x.Name == s); }
+            get { return this.FirstOrDefault(x => x.Name == s || x.Aliases.Contains(s)); }
         }
     }
 
@@ -17,6 +17,7 @@ namespace IgniteCLI
         public delegate void CommandFunc(Dictionary<string, string> cmdArgs);
 
         public string Name;
+        public string[] Aliases;
         public string Description;
         public CommandArgs Args = new CommandArgs();
         public CommandFunc Function;
@@ -47,13 +48,14 @@ namespace IgniteCLI
     {
         public CommandArg this[string s]
         {
-            get { return this.FirstOrDefault(x => x.Tag == s); }
+            get { return this.FirstOrDefault(x => x.Tag == s || x.Aliases.Contains(s)); }
         }
     }
 
     public class CommandArg
     {
         public string Tag;
+        public string[] Aliases;
         public string Description;
         public string InputFormat;
         public bool Required = true;

--- a/IgniteCLI/Ignite-CLI/IgniteCLI.csproj
+++ b/IgniteCLI/Ignite-CLI/IgniteCLI.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Ignite_CLI</RootNamespace>
     <PackageId>IgniteCLI</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors></Authors>
     <Company>Omega Airline Software</Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,8 +13,8 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/omega-airline-software/ignite-cli/master/LICENSE</PackageLicenseUrl>
     <PackageTags>CLI</PackageTags>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3.0</FileVersion>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4.0</FileVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
   


### PR DESCRIPTION
Resolves #34 

Use:
```
new Command
{
    Name = "Test",
    Aliases = new string[] { "t", "foo" },
    Args = new CommandArgs
    {
        new CommandArg
        {
            Tag = "arg",
            Aliases = new string[] { "a" },
        }
    },
    Function = args => { }
}
```


Also realized my comment in #27 isn't true, because the `Enum` I was referencing was a property, not a class. So I put the arg-grabbing functions back to their original names.